### PR TITLE
Add CSS styling for tables

### DIFF
--- a/sass/base.scss
+++ b/sass/base.scss
@@ -96,6 +96,35 @@ textarea {
   color: var(--text-color);
 }
 
+table {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 20px;
+  text-align: center;
+}
+
+thead tr {
+  background-color: var(--light-grey);
+}
+
+tbody tr:nth-child(odd) {
+  background-color: var(--lighter-gray);
+}
+
+tbody tr:nth-child(even) {
+  background-color: var(--white);
+}
+
+table {
+  background-color: var(--lighter-grey);
+}
+
+
+
 
 @media (max-width: 900px) {
   body {


### PR DESCRIPTION
Table were not styled at all, which is ugly.

I tried to reuse existing colors.

See https://blog.bitsofnetworks.org/riscv-performance-power-usage/ for an example.